### PR TITLE
Import alpheios in public instead of index.js

### DIFF
--- a/public/alpheios-embedded
+++ b/public/alpheios-embedded
@@ -1,0 +1,1 @@
+../node_modules/alpheios-embedded/dist/

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link rel="stylesheet" href="%PUBLIC_URL%/alpheios-embedded/style/style.min.css"/>
+    <link rel="stylesheet" href="%PUBLIC_URL%/alpheios-embedded/style/style-embedded.min.css"/>
+    <script src="%PUBLIC_URL%/alpheios-embedded/alpheios-embedded.min.js"></script>
+
     <title>D'Arcy Demo</title>
   </head>
   <body>

--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,11 @@ import { hydrate, render } from 'react-dom';
 import App from './components/App';
 import * as serviceWorker from './serviceWorker';
 
-import 'alpheios-embedded/dist/alpheios-embedded.min.js';
-
 import 'typeface-arimo';
 import './index.css';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'perseids-react-components/build/css/index.css';
-
-import 'alpheios-embedded/dist/style/style.min.css';
-import 'alpheios-embedded/dist/style/style-embedded.min.css';
 
 const rootElement = document.getElementById('root');
 


### PR DESCRIPTION
* Create a symlink to `node_modules/alpheios-embedded` in `public/`
* Include Alpheios code with script tags in `public.html` instead of importing it in the React App

This fixes an issue where Alpheios wasn't displaying definitions.